### PR TITLE
Support for multiple client instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 ```ruby
 require 'eet_cz'
 
-EET_CZ.configure do |c|
+client = EET_CZ::Client.new.tap do |c|
   c.endpoint              = EET_CZ::PG_EET_URL # or EET_CZ::PROD_EET_URL
   c.ssl_cert_file         = path_to('EET_CA1_Playground-CZ00000019.p12') # or 'pem' supported
   c.ssl_cert_key_file     = path_to('EET_CA1_Playground-CZ00000019.p12') # or 'pem'
@@ -35,12 +35,12 @@ EET_CZ.configure do |c|
   c.zjednoduseny_rezim    = false # `default: false`
 end
 
-receipt = EET_CZ::Receipt.new(dat_trzby:  Time.zone.now,
+receipt = client.build_receipt(dat_trzby:  Time.zone.now,
                               id_pokl:    '/4432/D12',
                               porad_cis:  '4/541/FR34',
                               celk_trzba: 25.5)
 
-request = EET_CZ::Request.new(receipt, prvni_zaslani: false) # default true
+request = client.build_request(receipt, prvni_zaslani: false) # default true
 response = request.run
 
 response.test?
@@ -73,4 +73,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/ciihla
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/eet_cz.rb
+++ b/lib/eet_cz.rb
@@ -16,9 +16,8 @@ require 'eet_cz/client'
 require 'eet_cz/akami_patch'
 
 module EET_CZ
-  include ActiveSupport::Configurable
-  # TODO: validation for config values?
 
   PG_EET_URL   = 'https://pg.eet.cz:443/eet/services/EETServiceSOAP/v3/'.freeze
   PROD_EET_URL = 'https://prod.eet.cz:443/eet/services/EETServiceSOAP/v3/'.freeze
+
 end

--- a/lib/eet_cz/akami_patch.rb
+++ b/lib/eet_cz/akami_patch.rb
@@ -2,23 +2,25 @@
 module Akami
   class WSSE
     class Certs
+      attr_accessor :cert_type, :private_key_type
+
       def cert
-        @cert ||= case File.extname(cert_file)
-                  when '.p12'
-                    OpenSSL::PKCS12.new(File.read(cert_file), private_key_password).certificate
+        @cert ||= case cert_type
+                  when 'p12'
+                    OpenSSL::PKCS12.new(cert_string, private_key_password).certificate
                   else
-                    OpenSSL::X509::Certificate.new File.read(cert_file)
-                  end if cert_file
+                    OpenSSL::X509::Certificate.new cert_string
+                  end if cert_string
       end
 
       # Returns an <tt>OpenSSL::PKey::RSA</tt> for the +private_key_file+.
       def private_key
-        @private_key ||= case File.extname(private_key_file)
-                         when '.p12'
-                           OpenSSL::PKCS12.new(File.read(private_key_file), private_key_password).key
+        @private_key ||= case private_key_type
+                         when 'p12'
+                           OpenSSL::PKCS12.new(private_key_string, private_key_password).key
                          else
-                           OpenSSL::PKey::RSA.new(File.read(private_key_file), private_key_password)
-                         end if private_key_file
+                           OpenSSL::PKey::RSA.new(private_key_string, private_key_password)
+                         end if private_key_string
       end
     end
 

--- a/lib/eet_cz/client.rb
+++ b/lib/eet_cz/client.rb
@@ -1,35 +1,85 @@
 # frozen_string_literal: true
 module EET_CZ
   class Client
-    def self.instance
-      new.client
+
+    DEFAULT_CERT_TYPE = 'p12'
+
+    attr_accessor :endpoint, :overovaci_mod, :debug_logger, :dic_popl, :id_pokl, :id_provoz, :zjednoduseny_rezim, :ssl_cert_key_password,
+        :ssl_cert_type, :ssl_cert_file, :ssl_cert_string, :ssl_cert_key_type, :ssl_cert_key_file, :ssl_cert_key_string
+
+    def initialize options = {}
+      options.each do |key, value|
+        self.send :"#{key}=", value
+      end
+
+      @endpoint ||= EET_CZ::PG_EET_URL
     end
 
-    def client
-      Savon.client(options) do
-        wsse_signature Akami::WSSE::Signature.new(Akami::WSSE::Certs.new(cert_file:            EET_CZ.config.ssl_cert_file,
-                                                                         private_key_file:     EET_CZ.config.ssl_cert_key_file,
-                                                                         private_key_password: EET_CZ.config.ssl_cert_key_password),
-                                                  digest: 'sha256')
+    def service
+      @service ||= Savon.client(options) do |service|
+        service.wsse_signature Akami::WSSE::Signature.new(certs, digest: 'sha256')
       end
+    end
+
+    def certs
+      return @certs if @certs
+
+      @certs = Akami::WSSE::Certs.new
+      @certs.cert_string = cert_string(:ssl_cert)
+      @certs.cert_type = cert_type(:ssl_cert)
+      @certs.private_key_string = cert_string(:ssl_cert_key)
+      @certs.private_key_type = cert_type(:ssl_cert_key)
+      @certs.private_key_password = ssl_cert_key_password
+      raise('certificate not found') unless @certs.cert_string
+
+      @certs
     end
 
     def options
       options = {
-        endpoint:             EET_CZ.config.endpoint,
+        endpoint:             endpoint,
         namespace:            'http://fs.mfcr.cz/eet/schema/v3',
         encoding:             'UTF-8',
         namespace_identifier: :eet
       }
 
-      if EET_CZ.config.debug_logger
+      if debug_logger
         options[:log_level]        = :debug
         options[:log]              = true
         options[:pretty_print_xml] = true
-        options[:logger]           = EET_CZ.config.debug_logger
+        options[:logger]           = debug_logger
       end
 
       options
     end
+
+    def build_receipt attributes = {}
+      EET_CZ::Receipt.new(attributes)
+    end
+
+    def build_request receipt, options = {}
+      EET_CZ::Request.new(self, receipt, options)
+    end
+
+  private
+
+    def cert_type kind
+      if type = send("#{kind}_type").present?
+        type
+      elsif file = send("#{kind}_file")
+        File.extname(file).delete('.')
+      else
+        DEFAULT_CERT_TYPE
+      end
+    end
+
+    def cert_string kind
+      if file = send("#{kind}_file")
+        File.read(file)
+      else
+        send("#{kind}_string")
+      end
+    end
+
   end
 end

--- a/ruby-eet-cz.gemspec
+++ b/ruby-eet-cz.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'webmock', '~> 2.3'
   spec.add_development_dependency 'vcr', '~> 3.0'
-  spec.add_runtime_dependency 'activesupport', '~> 5.0'
-  spec.add_runtime_dependency 'activemodel', '~> 5.0'
+  spec.add_runtime_dependency 'activesupport', '~> 4.2.7'
+  spec.add_runtime_dependency 'activemodel', '~> 4.2.7'
   spec.add_runtime_dependency 'savon', '~> 2.11.0'
 end

--- a/spec/eet/request_spec.rb
+++ b/spec/eet/request_spec.rb
@@ -2,6 +2,7 @@
 require 'spec_helper'
 
 describe EET_CZ::Request do
+
   let(:receipt) do
     EET_CZ::Receipt.new(dat_trzby:  Time.parse('2016-08-05T00:30:12+02:00'),
                         id_pokl:    '/5546/RO24',
@@ -9,7 +10,7 @@ describe EET_CZ::Request do
                         celk_trzba: 34_113.00)
   end
 
-  let(:request) { EET_CZ::Request.new(receipt) }
+  let(:request) { client.build_request(receipt) }
 
   let(:test_pem_pkp) do
     %(JvCv0lXfT74zuviJaHeO91guUfum1MKhq0NNPxW0YlBGvIIt+I4QxEC3QP6BRwEkIS14n2WN+9oQ8nhQPYwZX7L4W9Ie7CYv1ojcl/
@@ -23,21 +24,15 @@ zQO0vcC93k5DEWEoytTIAsKd6jKSO7eama8Qe+d0wq9vBzudkfLgCe2C1iERJuyHknhjo9KOx10h5wk9
 szSOdqlAdkey7M6m12AQW0LkBSPqPUi3NWa+Flo9xAPRyEKA49EQpndngu+kgPncElIfczSyhWOdQVq3D9FSwRD1ZXaY7tvyYgWLmNNF3xNn3ahCN0Hu41+wMPsqLGQw==).gsub(/\s/, '').strip
   end
 
-  before(:each) do
-    EET_CZ.configure do |config|
-      config.dic_popl = 'CZ1212121218'
-    end
-  end
-
   it 'returns instance' do
     expect(request).to be_an_instance_of(EET_CZ::Request)
   end
 
   context 'p12 key' do
     before(:each) do
-      EET_CZ.configure do |config|
-        config.ssl_cert_key_file     = cert_fixture_path('EET_CA1_Playground-CZ00000019.p12')
-        config.ssl_cert_key_password = 'eet'
+      client.tap do |c|
+        c.ssl_cert_key_file     = cert_fixture_path('EET_CA1_Playground-CZ00000019.p12')
+        c.ssl_cert_key_password = 'eet'
       end
     end
 
@@ -56,24 +51,17 @@ szSOdqlAdkey7M6m12AQW0LkBSPqPUi3NWa+Flo9xAPRyEKA49EQpndngu+kgPncElIfczSyhWOdQVq3
 
   context 'pem key' do
     before(:each) do
-      EET_CZ.configure do |config|
-        config.ssl_cert_key_file     = cert_fixture_path('private_key.pem')
-        config.ssl_cert_key_password = nil
+      client.tap do |c|
+        c.ssl_cert_key_file     = cert_fixture_path('private_key.pem')
+        c.ssl_cert_key_password = nil
       end
     end
 
     describe 'pkp' do
-      it 'valid' do
+      it 'is valid' do
         expect(request.pkp).to eq(test_pem_pkp)
       end
     end
   end
 
-  context 'client' do
-    let(:client) { request.client }
-
-    it 'returns instance' do
-      expect(client).to be_an_instance_of(Savon::Client)
-    end
-  end
 end

--- a/spec/eet_spec.rb
+++ b/spec/eet_spec.rb
@@ -2,21 +2,9 @@
 require 'spec_helper'
 
 describe EET_CZ do
+
   it 'has a version number' do
     expect(EET_CZ::VERSION).not_to be nil
   end
 
-  describe 'configure' do
-    before do
-      EET_CZ.configure do |config|
-        config.dic_popl = 'CZ123456789'
-        config.id_provoz = '12345'
-      end
-    end
-
-    it 'returns correct data' do
-      expect(EET_CZ.config.dic_popl).to eq('CZ123456789')
-      expect(EET_CZ.config.id_provoz).to eq('12345')
-    end
-  end
 end

--- a/spec/features/real_mode_spec.rb
+++ b/spec/features/real_mode_spec.rb
@@ -2,6 +2,7 @@
 require 'spec_helper'
 
 describe 'real mode' do
+
   let(:receipt) do
     EET_CZ::Receipt.new(dat_trzby:  Time.parse('2016-08-05T00:30:12+02:00'),
                         id_pokl:    '/5546/RO24',
@@ -9,30 +10,26 @@ describe 'real mode' do
                         celk_trzba: 34_113.00)
   end
 
-  let(:request) { EET_CZ::Request.new(receipt) }
+  let(:request) { client.build_request(receipt) }
 
   def do_request(cassette)
-    VCR.use_cassette cassette do
+    VCR.use_cassette cassette, match_requests_on: [:method, :uri] do
       request.run
     end
   end
 
   context 'real mode' do
     before(:each) do
-      EET_CZ.configure do |config|
-        config.overovaci_mod = false
-      end
+      client.overovaci_mod = false
     end
 
     context 'play_ground' do
       before(:each) do
-        EET_CZ.configure do |config|
-          config.endpoint = EET_CZ::PG_EET_URL
-        end
+        client.endpoint = EET_CZ::PG_EET_URL
       end
 
       context 'valid request' do
-        it 'success' do
+        it 'succeeds' do
           response = do_request('trzba/real_mode/play_ground/valid')
           expect(response).to be_an_instance_of(EET_CZ::Response::Success)
           expect(response).to be_success
@@ -45,12 +42,10 @@ describe 'real mode' do
 
       context 'invalid request' do
         before(:each) do
-          EET_CZ.configure do |config|
-            config.dic_popl = 'xxx'
-          end
+          client.dic_popl = 'xxx'
         end
 
-        it 'invalid request' do
+        it 'handles an invalid request' do
           response = do_request('trzba/real_mode/play_ground/invalid')
           expect(response).to be_an_instance_of(EET_CZ::Response::Error)
           expect(response).to be_test
@@ -62,19 +57,15 @@ describe 'real mode' do
 
     context 'production' do
       before(:each) do
-        EET_CZ.configure do |config|
-          config.endpoint = EET_CZ::PROD_EET_URL
-        end
+        client.endpoint = EET_CZ::PROD_EET_URL
       end
 
       context 'invalid request' do
         before(:each) do
-          EET_CZ.configure do |config|
-            config.dic_popl = 'xxx'
-          end
+          client.dic_popl = 'xxx'
         end
 
-        it 'invalid request' do
+        it 'handles an invalid request' do
           response = do_request('trzba/real_mode/production/invalid')
           expect(response).to be_an_instance_of(EET_CZ::Response::Error)
           expect(response).not_to be_success

--- a/spec/features/test_mode_spec.rb
+++ b/spec/features/test_mode_spec.rb
@@ -2,6 +2,7 @@
 require 'spec_helper'
 
 describe 'overeni' do
+
   let(:receipt) do
     EET_CZ::Receipt.new(dat_trzby:  Time.parse('2016-08-05T00:30:12+02:00'),
                         id_pokl:    '/5546/RO24',
@@ -9,7 +10,7 @@ describe 'overeni' do
                         celk_trzba: 34_113.00)
   end
 
-  let(:request) { EET_CZ::Request.new(receipt) }
+  let(:request) { client.build_request(receipt) }
 
   def do_request(cassette)
     VCR.use_cassette cassette do
@@ -19,27 +20,24 @@ describe 'overeni' do
 
   context 'test mode' do
     before(:each) do
-      EET_CZ.configure do |config|
-        config.overeni               = true
-        config.ssl_cert_file         = cert_fixture_path('EET_CA1_Playground-CZ00000019.p12')
-        config.ssl_cert_key_file     = cert_fixture_path('EET_CA1_Playground-CZ00000019.p12')
-        config.ssl_cert_key_password = 'eet'
-        config.dic_popl              = 'CZ00000019'
+      client.tap do |c|
+        c.overovaci_mod         = true
+        c.ssl_cert_file         = cert_fixture_path('EET_CA1_Playground-CZ00000019.p12')
+        c.ssl_cert_key_file     = cert_fixture_path('EET_CA1_Playground-CZ00000019.p12')
+        c.ssl_cert_key_password = 'eet'
+        c.dic_popl              = 'CZ00000019'
       end
     end
 
     context 'play_ground' do
       before(:each) do
-        EET_CZ.configure do |config|
-          config.endpoint = EET_CZ::PG_EET_URL
-        end
+        client.endpoint = EET_CZ::PG_EET_URL
       end
 
       context 'valid request' do
         it 'success warning' do
-          EET_CZ.configure do |config|
-            config.dic_popl = 'CZ1212121218'
-          end
+          client.dic_popl = 'CZ1212121218'
+
           response = do_request('trzba/test_mode/play_ground/valid-warning')
           expect(response).to be_an_instance_of(EET_CZ::Response::Error)
           expect(response.kod).to eq(0)
@@ -64,9 +62,7 @@ describe 'overeni' do
 
       context 'invalid request' do
         before(:each) do
-          EET_CZ.configure do |config|
-            config.dic_popl = 'xxx'
-          end
+          client.dic_popl = 'xxx'
         end
 
         it 'invalid' do
@@ -82,9 +78,7 @@ describe 'overeni' do
 
     context 'production' do
       before(:each) do
-        EET_CZ.configure do |config|
-          config.endpoint = EET_CZ::PROD_EET_URL
-        end
+        client.endpoint = EET_CZ::PROD_EET_URL
       end
 
       xcontext 'valid request' do # Due to a valid SSL certificate
@@ -100,9 +94,7 @@ describe 'overeni' do
 
       context 'invalid request' do
         before(:each) do
-          EET_CZ.configure do |config|
-            config.dic_popl = 'xxx'
-          end
+          client.dic_popl = 'xxx'
         end
 
         it 'not valid' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,20 +8,7 @@ Dir['./spec/support/**/*.rb'].each { |file| require file }
 
 RSpec.configure do |config|
   config.include CertFixturePath
-
-  config.before(:each) do
-    EET_CZ.configure do |c|
-      c.endpoint              = EET_CZ::PG_EET_URL
-      c.ssl_cert_file         = cert_fixture_path('EET_CA1_Playground-CZ00000019.p12')
-      c.ssl_cert_key_file     = cert_fixture_path('EET_CA1_Playground-CZ00000019.p12')
-      c.ssl_cert_key_password = 'eet'
-      c.overovaci_mod         = true # Use only test mode! It sends overeni='true'
-      c.debug_logger          = false
-      c.dic_popl              = 'CZ00000019'
-      c.id_provoz             = '273'
-      c.zjednoduseny_rezim    = false # 0 - bezny rezim, 1 - zjednoduseny rezim
-    end
-  end
+  config.include SharedContext
 end
 
 VCR.configure do |config|

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+module SharedContext
+  extend RSpec::SharedContext
+
+  let(:client) do
+    EET_CZ::Client.new.tap do |c|
+      c.ssl_cert_file         = cert_fixture_path('EET_CA1_Playground-CZ00000019.p12')
+      c.ssl_cert_key_file     = cert_fixture_path('EET_CA1_Playground-CZ00000019.p12')
+      c.ssl_cert_key_password = 'eet'
+      c.overovaci_mod         = true # Use only test mode! It sends overeni='true'
+      c.debug_logger          = false
+      c.dic_popl              = 'CZ1212121218'
+      c.id_provoz             = '273'
+      c.zjednoduseny_rezim    = false # false - bezny rezim, true - zjednoduseny rezim
+    end
+  end
+end


### PR DESCRIPTION
I'd like to use the code in a multi-tenant application, that's why I changed the following:

- Moved configuration to the `Client` object
- Added support for passing certificates as a string
- Made `Client` responsible for building requests and receipts