### PR TITLE
Update default password for playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ client = EET_CZ::Client.new.tap do |c|
   c.endpoint              = EET_CZ::PG_EET_URL # or EET_CZ::PROD_EET_URL
   c.ssl_cert_file         = path_to('EET_CA1_Playground-CZ00000019.p12') # or 'pem' supported
   c.ssl_cert_key_file     = path_to('EET_CA1_Playground-CZ00000019.p12') # or 'pem'
-  c.ssl_cert_key_password = 'secret'
+  c.ssl_cert_key_password = 'eet'
   # OR specify:
   #  c.ssl_cert_type         = 'pem' # Defaults to extname from file or 'p12'
   #  c.ssl_cert_string       = 'certificate as String'
@@ -69,13 +69,13 @@ response.warnings
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. 
-Then, run `rake spec` to run the tests. 
+After checking out the repo, run `bin/setup` to install dependencies.
+Then, run `rake spec` to run the tests.
 You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 Use `rubocop -a` to keep the code as clean as possible.
 
-To install this gem onto your local machine, run `bundle exec rake install`. 
+To install this gem onto your local machine, run `bundle exec rake install`.
 To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing


### PR DESCRIPTION
Since the [example in README.md](https://github.com/ciihla/ruby-eet-cz/blame/master/README.md#L28-L29) points to default name for *playground* certificates, I thought that `c.ssl_cert_key_password = 'secret'` is the correct value for those. It is not. It should be "*eet*" as stated [in official manual](http://www.etrzby.cz/assets/cs/prilohy/EET_pristupove_provozni_informace_playground_3.1.pdf). I think that this patch will save a little hassle for newcomers.

Also removed some unnecessary blank trailing spaces in README.md.