### PR TITLE
Time.zone is nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ client = EET_CZ::Client.new.tap do |c|
   c.zjednoduseny_rezim    = false # `default: false`
 end
 
-receipt = client.build_receipt(dat_trzby:  Time.zone.now,
+receipt = client.build_receipt(dat_trzby:  Time.current,
                               id_pokl:    '/4432/D12',
                               porad_cis:  '4/541/FR34',
                               celk_trzba: 25.5,


### PR DESCRIPTION
When running sample code from `README.md`, I get following error:

```
$ bundle exec ruby ./bin/eet_ping.rb
./bin/eet_ping.rb:28:in `<main>': undefined method `now' for nil:NilClass (NoMethodError)
```

Not sure where is the root of the problem problem, but just using `Time.current` as stated in section [16.1.1 in active_support docs](http://guides.rubyonrails.org/active_support_core_extensions.html#extensions-to-time) fixed my problem.