### PR TITLE
Nicer sample debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,35 @@ response = request.run
 # For tests: EET_CZ::Request.fake! to disable EET call
 # Or EET_CZ::Request.real! { example.run } # request will be sent!
 
-response.test?
-response.success?
-response.fik
-response.bkp
-response.uuid_zpravy
-response.dat_prij
-response.dat_odmit
-response.error
-response.warnings
+puts JSON.pretty_generate(response.as_json)
+```
+
+Running the script above should print something like:
+
+```JSON
+{
+  "doc": [
+
+  ],
+  "warnings": [
+
+  ],
+  "uuid_zpravy": "96041020-2996-406d-a90b-f967336ee738",
+  "bkp": "A3DED039-31F4AB57-DDC741E5-8CA28070-624E149C",
+  "inner_doc": [
+    [
+      "fik",
+      "382fbe6d-fa67-413a-88d9-6048dc1bd4c0-ff"
+    ],
+    [
+      "test",
+      "true"
+    ]
+  ],
+  "fik": "382fbe6d-fa67-413a-88d9-6048dc1bd4c0-ff",
+  "test": "true",
+  "dat_prij": "2017-03-04T19:01:26+01:00"
+}
 ```
 
 ## Development


### PR DESCRIPTION
When running the sample code from `README.md` I got a lot of similar error messages:

```
./bin/eet_ping.rb:43:in `<main>': undefined method `dat_odmit' for #<EET_CZ::Response::Success:0x007f8ecb241f60> (NoMethodError)
```

That is mainly because [printing out sample response](https://github.com/ciihla/ruby-eet-cz/blame/master/README.md#L59-L67) calls all the possible fields no matter what type of response we got.

This PR modifies the example, so that is just dumps whole response.

Also added sample output.